### PR TITLE
Windows 脚本改进

### DIFF
--- a/Export_ONNX/F5_TTS/Optimize_ONNX.py
+++ b/Export_ONNX/F5_TTS/Optimize_ONNX.py
@@ -1,16 +1,23 @@
 import gc
 import os
 import subprocess
+import argparse
 
 import onnx.version_converter
 from onnxruntime.transformers.optimizer import optimize_model
 from onnxslim import slim
 
+parser = argparse.ArgumentParser(description='argument for each file')
+parser.add_argument("--model", type=str, default="F5_Preprocess.onnx")
+args = parser.parse_args()
+
+print("model: ", args.model)
+
 # Path Setting
 original_folder_path = "/home/DakeQQ/Downloads/F5_ONNX"                                 # The fp32 saved folder.
 optimized_folder_path = "/home/DakeQQ/Downloads/F5_Optimized"                           # The optimized folder.
-model_path = os.path.join(original_folder_path, "F5_Preprocess.onnx")                   # The original fp32 model name.  Must use "CPUExecutionProvider"
-optimized_model_path = os.path.join(optimized_folder_path, "F5_Preprocess.onnx")        # The optimized model name.
+model_path = os.path.join(original_folder_path, args.model)                   # The original fp32 model name.  Must use "CPUExecutionProvider"
+optimized_model_path = os.path.join(optimized_folder_path, args.model)        # The optimized model name.
 
 # model_path = os.path.join(original_folder_path, "F5_Transformer.onnx")                # The original fp32 model name.
 # optimized_model_path = os.path.join(optimized_folder_path, "F5_Transformer.onnx")     # The optimized model name.

--- a/export_windows.bat
+++ b/export_windows.bat
@@ -1,15 +1,20 @@
 @echo off
 chcp 65001
 
+SET "ONNX_RUNTIME_VERSION=1.20.1"
+
 pushd %~dp0
 
 SET "SCRIPT_DIR=%CD:\=/%"
 
 SET "EXPORT_DIR=%SCRIPT_DIR%/Output"
+SET "EXPORT_OP_DIR=%SCRIPT_DIR%/Output/Optimized"
 
 SET "F5_TTS_PROJECT_DIR=%SCRIPT_DIR%/F5-TTS"
 SET "DOWNLOAD_DIR=%SCRIPT_DIR%/Downloads"
+SET "INFER_PY_FILE=%SCRIPT_DIR%/F5-TTS-ONNX-Inference.py"
 SET "EXPORT_PY_FILE=%SCRIPT_DIR%/Export_ONNX/F5_TTS/Export_F5.py"
+SET "OPTIMIZE_PY_FILE=%SCRIPT_DIR%/Export_ONNX/F5_TTS/Optimize_ONNX.py"
 
 SET "F5_TTS_MODEL_DIR=%DOWNLOAD_DIR%/F5-TTS"
 SET "VOCOS_DIR=%DOWNLOAD_DIR%/vocos-mel-24khz"
@@ -31,10 +36,14 @@ if NOT EXIST "%EXPORT_DIR%" (
     mkdir "%EXPORT_DIR%"
 )
 
+if NOT EXIST "%EXPORT_OP_DIR%" (
+    mkdir "%EXPORT_OP_DIR%"
+)
+
 if NOT EXIST "%F5_TTS_PROJECT_DIR%" (
     @echo Clone F5-TTS project ...
     @echo.
-    git clone clone https://github.com/SWivid/F5-TTS.git
+    git clone https://github.com/SWivid/F5-TTS.git
     
     cd "%F5_TTS_PROJECT_DIR%"
     pip install -e .
@@ -50,24 +59,60 @@ if NOT EXIST "%VOCOS_DIR%" (
 
 pushd %SCRIPT_DIR%
 
-pip install onnxruntime-tools==1.7.0
+@echo Use onnxruntime version %ONNX_RUNTIME_VERSION%
+@echo.
+python -m pip install onnxruntime==%ONNX_RUNTIME_VERSION%
+python -m pip install onnxslim --upgrade
+
+@REM Recover bellow, if you want to use directml
+@rem pip uninstall onnxruntime onnxruntime-gpu onnxruntime-tools -y
+@rem python -m pip install onnxruntime-directml
 
 @rem change code for windows
 @echo modify code ...
 @echo.
+@echo modify %EXPORT_PY_FILE%
+call:ReplaceString "%EXPORT_PY_FILE%" "/home/DakeQQ/Downloads/F5-TTS-main" "%F5_TTS_PROJECT_DIR%"
+call:ReplaceString "%EXPORT_PY_FILE%" "/home/DakeQQ/Downloads/F5TTS_Base" "%F5_TTS_MODEL_DIR%/F5TTS_Base"
+call:ReplaceString "%EXPORT_PY_FILE%" "/home/DakeQQ/Downloads/vocos-mel-24khz" "%VOCOS_DIR%"
+call:ReplaceString "%EXPORT_PY_FILE%" "/home/DakeQQ/Downloads/F5_ONNX/" "%EXPORT_DIR%/"
+
+@echo modify %EXPORT_PY_FILE%
+call:ReplaceString "%INFER_PY_FILE%" "/home/DakeQQ/Downloads/F5-TTS-main/src/f5_tts/infer/examples/basic/generated.wav" "%EXPORT_DIR%/test_result.wav"
 call:ReplaceString "%EXPORT_PY_FILE%" "/home/DakeQQ/Downloads/F5-TTS-main" "%F5_TTS_PROJECT_DIR%"
 call:ReplaceString "%EXPORT_PY_FILE%" "/home/DakeQQ/Downloads/F5TTS_Base" "%F5_TTS_MODEL_DIR%/F5TTS_Base"
 call:ReplaceString "%EXPORT_PY_FILE%" "/home/DakeQQ/Downloads/vocos-mel-24khz" "%VOCOS_DIR%"
 call:ReplaceString "%EXPORT_PY_FILE%" "/home/DakeQQ/Downloads/F5_ONNX/" "%EXPORT_DIR%/"
 
 
+@echo modify "%INFER_PY_FILE%"
+call:ReplaceString "%INFER_PY_FILE%" "F5_Preprocess.ort" "F5_Preprocess.onnx"
+call:ReplaceString "%INFER_PY_FILE%" "F5_Decode.ort" "F5_Decode.onnx"
+call:ReplaceString "%INFER_PY_FILE%" "/home/DakeQQ/Downloads/F5-TTS-main/src/f5_tts/infer/examples/basic/generated.wav" "%EXPORT_DIR%/infer_result.wav"
+call:ReplaceString "%INFER_PY_FILE%" "/home/DakeQQ/Downloads/F5-TTS-main" "%F5_TTS_PROJECT_DIR%"
+call:ReplaceString "%INFER_PY_FILE%" "/home/DakeQQ/Downloads/F5_Optimized/" "%EXPORT_DIR%/"
+
+
+@REM ---------------------- Start Python Execution--------------------------
+
 cd "%SCRIPT_DIR%/Export_ONNX/F5_TTS"
+
 python ./Export_F5.py
+python ./Optimize_ONNX.py
+
+@REM If you want to inference, relplace above to bellow:
+@REM pushd "%SCRIPT_DIR%"
+@REM python ./F5-TTS-ONNX-Inference.py
+
+
+@echo Processed !
+
+pause
 
 @rem restore code
 
-git checkout .
-
+git checkout -- Export_F5.py
+git checkout -- Optimize_ONNX.py
 exit
 
 


### PR DESCRIPTION
1. `添加了执行 Optimize_ONNX.py`:    因为这里需要循环优化三个文件，和 linux 脚本不同，windows 脚本写这个很麻烦，所以适当修改了一下 **Optimize_ONNX.py** ，Optimize_ONNX.py 可以完全以前的逻辑，就加了两行，如果外部参数，从参数获得文件名。其他逻辑都放在脚本中不影响源代码。

3. `将推理结果也放到 ouput 方便收听`: 脚本自动修改源码的生成文件路径，之前结果放在 F5TTS 项目目录，在的很深，这些变化都是通过脚本做，.py 源代码没有任何变化。

脚本用法没有变化，依然是一键自动 All donw。